### PR TITLE
Allow async-timeout 4.x too

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7,7 +7,7 @@ optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-async-timeout = ">=3.0,<4.0"
+async-timeout = ">=3.0.1,<5.0"
 attrs = ">=17.3.0"
 chardet = ">=2.0,<5.0"
 multidict = ">=4.5,<7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ include = [
 [tool.poetry.dependencies]
 python = "^3.8"
 aiohttp = "^3.7.4"
-async_timeout = "^3.0.1"
+async_timeout = ">=3.0.1,<5.0"
 
 [tool.poetry.dev-dependencies]
 asynctest = "^0.13.0"


### PR DESCRIPTION
There does not seem to be any need to restrict to the 3.x series; doing so causes problems with projects that need a newer one for some other purpose.

https://github.com/aio-libs/async-timeout/blob/f0a0914345b224448220aeb00d71e6a04a5d24bd/CHANGES.rst